### PR TITLE
Fix syntax, this is now POSIX shell complaint

### DIFF
--- a/fetch
+++ b/fetch
@@ -1,75 +1,75 @@
 #!/bin/sh
 
 # Colors
-c() { printf "\033[$1;$2m"; }
+c() { printf "\033[%s;%sm" "$1" "$2"; }
 
 # Import info
-source /etc/os-release
+. /etc/os-release
 
 # Get info functions
 Name() {
   read -r host < /etc/hostname;
-  printf "$USER@$host";
+  printf "%s@%s" "$USER" "$host";
 }
-Os() { printf $NAME; }
+Os() { printf "%s" "$NAME"; }
 Kernel() {
-  printf "$(read -r _ _ kern _ < /proc/version;
-  printf $kern)";
+  read -r _ _ kern _ < /proc/version;
+  printf "%s" "$kern";
 }
 Uptime() {
   IFS=. read -r up _ < /proc/uptime;
-  printf "$((up / 60 / 60 / 24))D $((up / 60 / 60 % 24))H $((up / 60 % 60))M";
+  printf "%dD %dH %dM" "$((up / 60 / 60 / 24))" "$((up / 60 / 60 % 24))" "$((up / 60 % 60))";
 }
-Shell() { printf "$( printf ${SHELL##*/} )"; }
+Shell() { printf "%s" "${SHELL##*/}"; }
 Desktop() {
   if [ "$DESKTOP_SESSION" != "" ]; then
-    printf "$DESKTOP_SESSION\n"
+    printf "%s\n" "$DESKTOP_SESSION"
   elif [ "$XDG_CURRENT_DESKTOP" != "" ]; then
-    printf "$XDG_CURRENT_DESKTOP\n"
+    printf "%s\n" "$XDG_CURRENT_DESKTOP"
   else
     for i in /proc/*/comm; do
       read -r p < "$i"
       case $p in
-        awesome|xmonad*|qtile|sway|i3|[bfo]*box|*wm*|*wm) printf "${p%%-*}"; break;;
+        awesome|xmonad*|qtile|sway|i3|[bfo]*box|*wm*) printf "%s" "${p%%-*}"; break;;
       esac
     done
   fi
 }
 Memory() {
   while IFS=':k ' read -r mem1 mem2 _; do
-    case $mem1 in
+    case "$mem1" in
       MemTotal)
-        memt=$(( $mem2 / 1024 ));;
+        memt="$(( mem2 / 1024 ))";;
       MemAvailable)
-        memu=$(($memt - $mem2 / 1024));;
+        memu="$(( memt - mem2 / 1024))";;
     esac;
   done < /proc/meminfo;
-  printf "$memu""Mib"" / ""$memt""Mib";
+  printf "%dMib / %dMib" "$memu" "$memt";
 }
 
 help() { printf "Usage: fetch [ -c config | -h ]
 Report issue at: https://github.com/manas140/fetch\n\n" && exit; }
 
 # Import config
-if [ -f $HOME/.config/fetch/conf ]; then
-  source $HOME/.config/fetch/conf
+if [ -f "$HOME"/.config/fetch/conf ]; then
+  . "$HOME"/.config/fetch/conf
 else
   # Default Config
   conf() {
     printf "\n"
-    printf "$(c 1 31) $(Name)\n"
-    printf "$(c 1 32) Os: $(Os)\n"
-    printf "$(c 1 33) Kernel: $(Kernel)\n"
-    printf "$(c 1 34) Uptime: $(Uptime)\n"
-    printf "$(c 1 35) Shell: $(Shell)\n"
-    printf "$(c 1 36) DE/WM: $(Desktop)\n"
-    printf "$(c 1 37) Memory: $(Memory)\n"
+    printf "%s %s\n" "$(c 1 31)" "$(Name)"
+    printf "%s Os: %s\n" "$(c 1 32)" "$(Os)"
+    printf "%s Kernel: %s\n" "$(c 1 33)" "$(Kernel)"
+    printf "%s Uptime: %s\n" "$(c 1 34)" "$(Uptime)"
+    printf "%s Shell: %s\n" "$(c 1 35)" "$(Shell)"
+    printf "%s DE/WM: %s\n" "$(c 1 36)" "$(Desktop)"
+    printf "%s Memory: %s\n" "$(c 1 37)" "$(Memory)"
     printf "\n"
   }
 fi
 
 case "$1" in
-  *-c*) [ -f "$2" ] && source $2 ;;
+  *-c*) [ -f "$2" ] && . "$2" ;;
   *-h*) help;;
 esac
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 case $1 in
-  *u*) sudo rm -r /usr/local/bin/fetch && printf "[*] fetch Uninstalled\n"; mkdir -p $HOME/.config/fetch;;
+  *u*) sudo rm -r /usr/local/bin/fetch && printf "[*] fetch Uninstalled\n"; mkdir -p "$HOME"/.config/fetch;;
   *i*) sudo cp -r fetch /usr/local/bin/fetch && printf "[*] fetch Installed\n";;
   *) printf "Usage: ./install.sh [ -i install | -u uninstall ]\n"
 esac


### PR DESCRIPTION
- Use `"$var"` instead of `$var`; read: [SC2046](https://github.com/koalaman/shellcheck/wiki/SC2046)
- Use `printf "%s Uptime" "$var"` instead of `printf "$var Uptime"`; read: [SC2059](https://github.com/koalaman/shellcheck/wiki/SC2059)
- Use `.` instead of `source`; the source command doesn't exist in POSIX complaint shells like `dash`, `ksh`, etc.
- In Line 33, `*wm*` overrides `*wm`, so what's the point of the last `*wm`?
Changing `awesome|xmonad*|qtile|sway|i3|[bfo]*box|*wm*|*wm)` to `awesome|xmonad*|qtile|sway|i3|[bfo]*box|*wm*)`